### PR TITLE
Fix dynamic constants

### DIFF
--- a/lib/xirr/config.rb
+++ b/lib/xirr/config.rb
@@ -17,6 +17,15 @@ module Xirr
   # Iterates though default values and sets in config
   default_values.each do |key, value|
     self.config.send("#{key.to_sym}=", value)
-    const_set key.to_s.upcase.to_sym, value
+  end
+
+  # Allow config values to be accessed via module "constants"
+  # e.g. Xirr::REPLACE_FOR_NIL instead of Xirr.config.replace_for_nil
+  def self.const_missing(symbol)
+    config_key = symbol.to_s.downcase.to_sym
+
+    super unless self.config.has_key?(config_key)
+
+    self.config[config_key]
   end
 end

--- a/lib/xirr/version.rb
+++ b/lib/xirr/version.rb
@@ -1,4 +1,4 @@
 module Xirr
   # Version of the Gem
-  VERSION = '1.0.0'
+  VERSION = '1.1.0'
 end

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -1,0 +1,27 @@
+require_relative 'test_helper'
+
+describe 'Xirr' do
+  it 'has constants for each item in the config' do
+    Xirr.config.each do |key, value|
+      constant_value = Xirr.const_get(key.to_s.upcase.to_sym)
+
+      if value.nil?
+        assert_nil constant_value
+      else
+        assert_equal value, constant_value
+      end
+    end
+  end
+
+  it 'uses configured values as constants' do
+    Xirr.configure do |config|
+      config.replace_for_nil = nil
+    end
+
+    assert_nil Xirr::REPLACE_FOR_NIL
+  end
+
+  it "raises an error if an unconfigured constant is used" do
+    assert_raises(NameError) { Xirr::UNDEFINED_CONSTANT }
+  end
+end


### PR DESCRIPTION
Switch from using `#const_set` to overriding `#const_missing` to define module constants based on the configuration.

As the `default_values.each` loop is executed when the module is loaded, the constants that were created were based on the default values. Any updates made using `Xirr.configure` were not reflected in those constants.

Instead of setting constants using `const_set` we change to intercepting `#const_missing`. This allows us to return the current value from the configuration whenever each constant is used.