### PR TITLE
Replace BigDecimal.new with BigDecimal()

### DIFF
--- a/lib/xirr/bisection.rb
+++ b/lib/xirr/bisection.rb
@@ -11,8 +11,8 @@ module Xirr
     def xirr midpoint, options
 
       # Initial values
-      left  = [BigDecimal.new(-0.99999999, Xirr::PRECISION), cf.irr_guess].min
-      right = [BigDecimal.new(9.99999999, Xirr::PRECISION), cf.irr_guess + 1].max
+      left  = [BigDecimal(-0.99999999, Xirr::PRECISION), cf.irr_guess].min
+      right = [BigDecimal(9.99999999, Xirr::PRECISION), cf.irr_guess + 1].max
       @original_right = right
       midpoint ||= cf.irr_guess
 
@@ -93,4 +93,3 @@ module Xirr
   end
 
 end
-

--- a/lib/xirr/cashflow.rb
+++ b/lib/xirr/cashflow.rb
@@ -59,7 +59,7 @@ module Xirr
       method, options = process_options(method, options)
       if invalid?
         raise ArgumentError, invalid_message if options[:raise_exception]
-        BigDecimal.new(0, Xirr::PRECISION)
+        BigDecimal(0, Xirr::PRECISION)
       else
         xirr = choose_(method).send :xirr, guess, options
         xirr = choose_(other_calculation_method(method)).send(:xirr, guess, options) if (xirr.nil? || xirr.nan?) && fallback

--- a/lib/xirr/newton_method.rb
+++ b/lib/xirr/newton_method.rb
@@ -20,7 +20,7 @@ module Xirr
       # define default values
       values.each do |key, value|
         define_method key do
-          BigDecimal.new(value, Xirr::PRECISION)
+          BigDecimal(value, Xirr::PRECISION)
         end
       end
 
@@ -35,8 +35,8 @@ module Xirr
       # Necessary for #nlsolve
       # @param x [BigDecimal]
       def values(x)
-        value = @transactions.send(@function, BigDecimal.new(x[0].to_s, Xirr::PRECISION))
-        [BigDecimal.new(value.to_s, Xirr::PRECISION)]
+        value = @transactions.send(@function, BigDecimal(x[0].to_s, Xirr::PRECISION))
+        [BigDecimal(value.to_s, Xirr::PRECISION)]
       end
     end
 

--- a/lib/xirr/version.rb
+++ b/lib/xirr/version.rb
@@ -1,4 +1,4 @@
 module Xirr
   # Version of the Gem
-  VERSION = '1.1.0'
+  VERSION = '1.1.1'
 end

--- a/test/test_cashflow.rb
+++ b/test/test_cashflow.rb
@@ -136,7 +136,7 @@ describe 'Cashflows' do
     end
 
     it 'returns 0 instead of exception ' do
-      assert_equal BigDecimal.new(0, 6), @cf.xirr
+      assert_equal BigDecimal(0, 6), @cf.xirr
     end
 
 


### PR DESCRIPTION
Replace the usage of `BigDecimal#new` with the newer `BigDecimal()` constructor. This is necessary to support higher Ruby versions.